### PR TITLE
make it has ability to collecting responses

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -120,7 +120,7 @@ class Manager extends PhalconManager
         return $status;
     }
 
-    public function fireEvents(string $eventType, Event $event, &$status = null): ?bool
+    public function fireEvents(string $eventType, Event $event, &$status = null): mixed
     {
         $events = $this->events;
         $fireEvents = $events[$eventType] ?? null;


### PR DESCRIPTION
when we need to show up event manager's response which is inside the `$status`. However, each response's value is string.

Produce the error:
```php
$this->eventsManager->collectResponses(true);
$this->eventsManager->attach('byline:afterCreated', function() {
    return 'first response';
});
//Attach a listener
$this->eventsManager->attach('byline:afterCreated', function() {
    return 'second response';
});

//Fire the event
$this->eventsManager->fire('byline:afterCreated', null);

//Get all the collected responses
print_r($this->eventsManager->getResponses());
die();
```